### PR TITLE
load all elm files in the directory as a dependency for webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 var fs      = require('fs');
 var utils   = require('loader-utils');
 var compile = require('node-elm-compiler').compile;
+var path    = require('path');
+var glob    = require('glob');
 
 var extend = function (obj) {
   var source, prop, i, l;
@@ -52,8 +54,17 @@ var loadConfig = function (source, callback) {
   callback(null, config);
 };
 
+var addDependencies = function (basePath, addDependency) {
+  glob(basePath + "/**/*.elm", function (err, files) {
+    for (var i = 0; i < files.length; i++) {
+      addDependency(files[i]);
+    }
+  });
+}
+
 var compileResource = function (resource, config, callback) {
   try {
+    addDependencies(path.dirname(resource), this.addDependency);
     compile(resource, config).on('close', function (exitCode) {
       if (exitCode === 0) {
         fs.readFile(config.output, 'utf8', callback);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "./node_modules/.bin/nodeunit test/loader.js"
   },
   "dependencies": {
+    "glob": "^6.0.1",
     "loader-utils": "^0.2.5",
     "node-elm-compiler": "^2.0.0"
   },


### PR DESCRIPTION
This causes them to be watched by webpack. This addresses #4.

Now it doesn't do any caching, so all files are added again after each update.
